### PR TITLE
Issue #25121: Implement printing images stored as bytea in file table

### DIFF
--- a/OpenRPT/renderer/orprerender.cpp
+++ b/OpenRPT/renderer/orprerender.cpp
@@ -843,6 +843,11 @@ qreal ORPreRenderPrivate::renderSection(const ORSectionData & sectionData)
           imgdata = QUUDecode(uudata);
         }
       }
+      else
+      {
+          // decode the provided inline data
+          imgdata = QUUDecode(uudata);
+      }
 
       QImage img;
 

--- a/OpenRPT/renderer/orutils.cpp
+++ b/OpenRPT/renderer/orutils.cpp
@@ -172,5 +172,24 @@ const QVariant orData::getVariant() const
 	return v;
 }
 
+const QByteArray &orData::getByteValue()
+{
+  if (_valid)
+  {
+    qbaValue = qryThis->getQuery()->value(qstrField).toByteArray();
+  }
 
+  return qbaValue;
+}
 
+const int orData::getType()
+{
+  int type;
+  if (_valid)
+  {
+      QSqlField field = qryThis->getQuery()->record().field(qstrField);
+      type = field.type();
+  }
+
+  return type;
+}

--- a/OpenRPT/renderer/orutils.h
+++ b/OpenRPT/renderer/orutils.h
@@ -23,7 +23,8 @@
 #include <QString>
 #include <QStringList>
 #include <QSqlDatabase>
-
+#include <QSqlRecord>
+#include <QSqlField>
 #include <xsqlquery.h>
 #include <parameter.h>
 
@@ -72,6 +73,7 @@ class orData {
     orQuery *qryThis;
     QString qstrField;
     QString qstrValue;
+    QByteArray qbaValue;
     bool    _valid;
 
   public:
@@ -84,6 +86,8 @@ class orData {
 
     const QString &getValue();
 	const QVariant getVariant() const;
+    const QByteArray &getByteValue();
+    const int getType();
 };
 
 #endif // __ORUTILS_H__


### PR DESCRIPTION
This PR adds support for printing images that have been saved into the file table instead of from the images table. It does so by making a method on the orData object that will give you the column type as returned from  PostgreSQL. The renderer can use this method to make a decision about what method to use to get the data and then continue rendering it depending if it is uuencoded or just a straight byte array. 

There is no interface change for the end user. In order to print files from the file table, simply add an image to the report as you normally would, using a query along the lines of:

``SELECT file_stream FROM file WHERE file_id = ID_HERE;``

Since the idea is to be able to pull have a direct link to the file from the docass table. You can use any image stored in any bytea column in the database however, and are not limited to images from the file table. 