### PR TITLE
Revert "Revert "bump version number""

### DIFF
--- a/common/data.cpp
+++ b/common/data.cpp
@@ -25,7 +25,7 @@
 QString OpenRPT::build     = QObject::tr("%1 %2").arg(__DATE__, __TIME__);
 QString OpenRPT::copyright = QObject::tr("Copyright (c) 2002-2015, OpenMFG, LLC.");
 bool    OpenRPT::loggedIn  = false;
-QString OpenRPT::version   = QObject::tr("3.3.8");
+QString OpenRPT::version   = QObject::tr("3.3.9");
 
 LanguageOptions OpenRPT::languages(0);
 


### PR DESCRIPTION
Reverts xtuple/openrpt#51
Needed to roll back version number so linux distributions could work off a revised tag (v3.3.8+1). Now rolling version number forward again for the next release.