### PR TITLE
Fix mql parser conditional

### DIFF
--- a/MetaSQL/metasqlqueryparser.h
+++ b/MetaSQL/metasqlqueryparser.h
@@ -95,7 +95,7 @@ class MetaSQLInfoDefault : public MetaSQLInfo {
             std::list<std::string>::iterator strlit = find(list.begin(), list.end(), name);
             std::string v;
             if(strlit != list.end()) {
-                v = _values[name].at((pos != -1 ? getValuePos(name) : pos));
+                v = _values[name].at((pos == -1 ? getValuePos(name) : pos));
             }
             if(param) {
                 std::string n = "'";


### PR DESCRIPTION
Function defaults position to -1, but the ternary was choosing to use -1 in that case instead of looking up the position by name and the .at call to -1 causes an out of bounds exception.

This time based on 3_3_x..