### PR TITLE
[20284] enable edit and delete buttons only when item is selected

### DIFF
--- a/OpenRPT/wrtembed/colorlist.cpp
+++ b/OpenRPT/wrtembed/colorlist.cpp
@@ -36,7 +36,7 @@ ColorList::ColorList(QWidget* parent, Qt::WindowFlags fl)
     connect(_btnEdit, SIGNAL(clicked()), this, SLOT(_btnEdit_clicked()));
     connect(_btnDelete, SIGNAL(clicked()), this, SLOT(_btnDelete_clicked()));
     connect(_lbColors, SIGNAL(itemDoubleClicked(QListWidgetItem*)), this, SLOT(_lbColors_dblClick(QListWidgetItem*)));
-    connect(_lbColors, SIGNAL(itemClicked(QListWidgetItem*)), this, SLOT(sEnableButtons()));
+    connect(_lbColors, SIGNAL(itemSelectionChanged()), this, SLOT(sEnableButtons()));
 
     _btnEdit->setEnabled(false);
     _btnDelete->setEnabled(false);
@@ -166,6 +166,6 @@ void ColorList::init( QMap<QString, QColor> * cmap)
 
 void ColorList::sEnableButtons()
 {
-  _btnEdit->setEnabled(true);
-  _btnDelete->setEnabled(true);
+  _btnEdit->setEnabled(!_lbColors->selectedItems().isEmpty());
+  _btnDelete->setEnabled(!_lbColors->selectedItems().isEmpty());
 }

--- a/OpenRPT/wrtembed/colorlist.cpp
+++ b/OpenRPT/wrtembed/colorlist.cpp
@@ -36,6 +36,10 @@ ColorList::ColorList(QWidget* parent, Qt::WindowFlags fl)
     connect(_btnEdit, SIGNAL(clicked()), this, SLOT(_btnEdit_clicked()));
     connect(_btnDelete, SIGNAL(clicked()), this, SLOT(_btnDelete_clicked()));
     connect(_lbColors, SIGNAL(itemDoubleClicked(QListWidgetItem*)), this, SLOT(_lbColors_dblClick(QListWidgetItem*)));
+    connect(_lbColors, SIGNAL(itemClicked(QListWidgetItem*)), this, SLOT(sEnableButtons()));
+
+    _btnEdit->setEnabled(false);
+    _btnDelete->setEnabled(false);
 }
 
 ColorList::~ColorList()
@@ -160,3 +164,8 @@ void ColorList::init( QMap<QString, QColor> * cmap)
     }
 }
 
+void ColorList::sEnableButtons()
+{
+  _btnEdit->setEnabled(true);
+  _btnDelete->setEnabled(true);
+}

--- a/OpenRPT/wrtembed/colorlist.h
+++ b/OpenRPT/wrtembed/colorlist.h
@@ -39,6 +39,7 @@ public slots:
     virtual void _btnEdit_clicked();
     virtual void _btnDelete_clicked();
     virtual void init( QMap<QString, QColor> * cmap );
+    virtual void sEnableButtons();
 
 protected:
     QMap<QString, QColor>* _colorMap;

--- a/OpenRPT/wrtembed/labeldefinitions.cpp
+++ b/OpenRPT/wrtembed/labeldefinitions.cpp
@@ -43,7 +43,7 @@ LabelDefinitions::LabelDefinitions(QWidget* parent, Qt::WindowFlags fl)
   connect(btnDelete, SIGNAL(clicked()), this, SLOT(btnDelete_clicked()));
   connect(btnAdd, SIGNAL(clicked()), this, SLOT(btnAdd_clicked()));
   connect(btnClose, SIGNAL(clicked()), this, SLOT(close()));
-  connect(ldList, SIGNAL(itemClicked(QListWidgetItem*)), this, SLOT(sEnableButtons()));
+  connect(ldList, SIGNAL(itemSelectionChanged()), this, SLOT(sEnableButtons()));
 
   btnEdit->setEnabled(false);
   btnDelete->setEnabled(false);
@@ -199,7 +199,7 @@ void LabelDefinitions::init( )
 
 void LabelDefinitions::sEnableButtons()
 {
-  btnEdit->setEnabled(true);
-  btnDelete->setEnabled(true);
+  btnEdit->setEnabled(!ldList->selectedItems().isEmpty());
+  btnDelete->setEnabled(!ldList->selectedItems().isEmpty());
 }
 

--- a/OpenRPT/wrtembed/labeldefinitions.cpp
+++ b/OpenRPT/wrtembed/labeldefinitions.cpp
@@ -43,6 +43,11 @@ LabelDefinitions::LabelDefinitions(QWidget* parent, Qt::WindowFlags fl)
   connect(btnDelete, SIGNAL(clicked()), this, SLOT(btnDelete_clicked()));
   connect(btnAdd, SIGNAL(clicked()), this, SLOT(btnAdd_clicked()));
   connect(btnClose, SIGNAL(clicked()), this, SLOT(close()));
+  connect(ldList, SIGNAL(itemClicked(QListWidgetItem*)), this, SLOT(sEnableButtons()));
+
+  btnEdit->setEnabled(false);
+  btnDelete->setEnabled(false);
+
 }
 
 LabelDefinitions::~LabelDefinitions()
@@ -190,5 +195,11 @@ void LabelDefinitions::init( )
   {
     ldList->addItem(*label);
   }
+}
+
+void LabelDefinitions::sEnableButtons()
+{
+  btnEdit->setEnabled(true);
+  btnDelete->setEnabled(true);
 }
 

--- a/OpenRPT/wrtembed/labeldefinitions.h
+++ b/OpenRPT/wrtembed/labeldefinitions.h
@@ -40,6 +40,7 @@ public slots:
     virtual void btnDelete_clicked();
     virtual void btnAdd_clicked();
     virtual void init();
+    virtual void sEnableButtons();
 
 protected slots:
     virtual void languageChange();

--- a/OpenRPT/wrtembed/querylist.cpp
+++ b/OpenRPT/wrtembed/querylist.cpp
@@ -38,6 +38,10 @@ QueryList::QueryList(QWidget* parent, Qt::WindowFlags fl)
   connect(btnEdit, SIGNAL(clicked()), this, SLOT(btnEdit_clicked()));
   connect(btnDelete, SIGNAL(clicked()), this, SLOT(btnDelete_clicked()));
   connect(btnAdd, SIGNAL(clicked()), this, SLOT(btnAdd_clicked()));
+  connect(lbQuerys, SIGNAL(itemClicked(QListWidgetItem*)), this, SLOT(sEnableButtons()));
+  
+  btnEdit->setEnabled(false);
+  btnDelete->setEnabled(false);
 }
 
 QueryList::~QueryList()
@@ -161,3 +165,8 @@ void QueryList::init( QuerySourceList * qsl )
   }
 }
 
+void QueryList::sEnableButtons()
+{
+  btnEdit->setEnabled(true);
+  btnDelete->setEnabled(true);
+}

--- a/OpenRPT/wrtembed/querylist.cpp
+++ b/OpenRPT/wrtembed/querylist.cpp
@@ -38,7 +38,7 @@ QueryList::QueryList(QWidget* parent, Qt::WindowFlags fl)
   connect(btnEdit, SIGNAL(clicked()), this, SLOT(btnEdit_clicked()));
   connect(btnDelete, SIGNAL(clicked()), this, SLOT(btnDelete_clicked()));
   connect(btnAdd, SIGNAL(clicked()), this, SLOT(btnAdd_clicked()));
-  connect(lbQuerys, SIGNAL(itemClicked(QListWidgetItem*)), this, SLOT(sEnableButtons()));
+  connect(lbQuerys, SIGNAL(itemSelectionChanged()), this, SLOT(sEnableButtons()));
   
   btnEdit->setEnabled(false);
   btnDelete->setEnabled(false);
@@ -167,6 +167,6 @@ void QueryList::init( QuerySourceList * qsl )
 
 void QueryList::sEnableButtons()
 {
-  btnEdit->setEnabled(true);
-  btnDelete->setEnabled(true);
+  btnEdit->setEnabled(!lbQuerys->selectedItems().isEmpty());
+  btnDelete->setEnabled(!lbQuerys->selectedItems().isEmpty());
 }

--- a/OpenRPT/wrtembed/querylist.h
+++ b/OpenRPT/wrtembed/querylist.h
@@ -42,6 +42,7 @@ public slots:
     virtual void btnDelete_clicked();
     virtual void btnAdd_clicked();
     virtual void init( QuerySourceList * );
+    virtual void sEnableButtons();
 
 protected:
     QuerySourceList * qsList;

--- a/OpenRPT/wrtembed/reportparameterlist.cpp
+++ b/OpenRPT/wrtembed/reportparameterlist.cpp
@@ -35,8 +35,11 @@ ReportParameterList::ReportParameterList(QWidget* parent, Qt::WindowFlags fl)
     connect(_btnEdit, SIGNAL(clicked()), this, SLOT(sEdit()));
     connect(_btnDelete, SIGNAL(clicked()), this, SLOT(sDelete()));
     connect(_lbParameters, SIGNAL(itemDoubleClicked(QListWidgetItem*)), this, SLOT(sEdit(QListWidgetItem*)));
+    connect(_lbParameters, SIGNAL(itemClicked(QListWidgetItem*)), this, SLOT(sEnableButtons()));
 
     _map = 0;
+    _btnEdit->setEnabled(false);
+    _btnDelete->setEnabled(false);
 }
 
 ReportParameterList::~ReportParameterList()
@@ -121,3 +124,8 @@ void ReportParameterList::setList(QMap<QString, ORParameter> * m)
     }
 }
 
+void ReportParameterList::sEnableButtons()
+{
+  _btnEdit->setEnabled(true);
+  _btnDelete->setEnabled(true);
+}

--- a/OpenRPT/wrtembed/reportparameterlist.cpp
+++ b/OpenRPT/wrtembed/reportparameterlist.cpp
@@ -35,7 +35,7 @@ ReportParameterList::ReportParameterList(QWidget* parent, Qt::WindowFlags fl)
     connect(_btnEdit, SIGNAL(clicked()), this, SLOT(sEdit()));
     connect(_btnDelete, SIGNAL(clicked()), this, SLOT(sDelete()));
     connect(_lbParameters, SIGNAL(itemDoubleClicked(QListWidgetItem*)), this, SLOT(sEdit(QListWidgetItem*)));
-    connect(_lbParameters, SIGNAL(itemClicked(QListWidgetItem*)), this, SLOT(sEnableButtons()));
+    connect(_lbParameters, SIGNAL(itemSelectionChanged()), this, SLOT(sEnableButtons()));
 
     _map = 0;
     _btnEdit->setEnabled(false);
@@ -126,6 +126,6 @@ void ReportParameterList::setList(QMap<QString, ORParameter> * m)
 
 void ReportParameterList::sEnableButtons()
 {
-  _btnEdit->setEnabled(true);
-  _btnDelete->setEnabled(true);
+  _btnEdit->setEnabled(!_lbParameters->selectedItems().isEmpty());
+  _btnDelete->setEnabled(!_lbParameters->selectedItems().isEmpty());
 }

--- a/OpenRPT/wrtembed/reportparameterlist.h
+++ b/OpenRPT/wrtembed/reportparameterlist.h
@@ -46,6 +46,7 @@ protected slots:
     virtual void sEdit();
     virtual void sDelete();
     virtual void sEdit( QListWidgetItem * );
+    virtual void sEnableButtons();
 
 };
 

--- a/OpenRPT/wrtembed/sectioneditor.cpp
+++ b/OpenRPT/wrtembed/sectioneditor.cpp
@@ -56,7 +56,7 @@ SectionEditor::SectionEditor(QWidget* parent, Qt::WindowFlags fl)
     connect(cbFootOdd, SIGNAL(toggled(bool)), this, SLOT(cbFootOdd_toggled(bool)));
     connect(cbHeadAny, SIGNAL(toggled(bool)), this, SLOT(cbHeadAny_toggled(bool)));
     connect(cbFootAny, SIGNAL(toggled(bool)), this, SLOT(cbFootAny_toggled(bool)));
-    connect(lbSections, SIGNAL(itemClicked(QListWidgetItem*)), this, SLOT(sEnableButtons()));
+    connect(lbSections, SIGNAL(itemSelectionChanged()), this, SLOT(sEnableButtons()));
 
     btnEdit->setEnabled(false);
     btnRemove->setEnabled(false);
@@ -364,6 +364,6 @@ void SectionEditor::cbFootAny_toggled( bool yes )
 
 void SectionEditor::sEnableButtons()
 {
-  btnEdit->setEnabled(true);
-  btnRemove->setEnabled(true);
+  btnEdit->setEnabled(!lbSections->selectedItems().isEmpty());
+  btnRemove->setEnabled(!lbSections->selectedItems().isEmpty());
 }

--- a/OpenRPT/wrtembed/sectioneditor.cpp
+++ b/OpenRPT/wrtembed/sectioneditor.cpp
@@ -56,6 +56,10 @@ SectionEditor::SectionEditor(QWidget* parent, Qt::WindowFlags fl)
     connect(cbFootOdd, SIGNAL(toggled(bool)), this, SLOT(cbFootOdd_toggled(bool)));
     connect(cbHeadAny, SIGNAL(toggled(bool)), this, SLOT(cbHeadAny_toggled(bool)));
     connect(cbFootAny, SIGNAL(toggled(bool)), this, SLOT(cbFootAny_toggled(bool)));
+    connect(lbSections, SIGNAL(itemClicked(QListWidgetItem*)), this, SLOT(sEnableButtons()));
+
+    btnEdit->setEnabled(false);
+    btnRemove->setEnabled(false);
 }
 
 SectionEditor::~SectionEditor()
@@ -356,4 +360,10 @@ void SectionEditor::cbFootAny_toggled( bool yes )
     else
       scene->removePageFootAny();
   }
+}
+
+void SectionEditor::sEnableButtons()
+{
+  btnEdit->setEnabled(true);
+  btnRemove->setEnabled(true);
 }

--- a/OpenRPT/wrtembed/sectioneditor.h
+++ b/OpenRPT/wrtembed/sectioneditor.h
@@ -55,6 +55,7 @@ public slots:
     virtual void cbFootOdd_toggled( bool yes );
     virtual void cbHeadAny_toggled( bool yes );
     virtual void cbFootAny_toggled( bool yes );
+    virtual void sEnableButtons();
 
 protected:
     DocumentScene * scene;


### PR DESCRIPTION
Edit and delete buttons should not be enabled if the corresponding list they affect is empty, or the user hasnt selected and item yet (don't make assumptions about which item the user wants to edit/delete)