### PR TITLE
[32633] User is unable to select ‘Properties’ from the context menu while inserting ‘Cross Tab’.

### DIFF
--- a/OpenRPT/wrtembed/reporthandler.cpp
+++ b/OpenRPT/wrtembed/reporthandler.cpp
@@ -1259,6 +1259,7 @@ void ReportHandler::editProperties()
         case ORGraphicsTextItem::Type:
         case ORGraphicsBarcodeItem::Type:
         case ORGraphicsImageItem::Type:
+        case ORGraphicsCrossTabItem::Type:
         case ORGraphicsGraphItem::Type:
           (static_cast<ORGraphicsRectItem*>(list.at(i)))->properties(gw);
           break;


### PR DESCRIPTION
Crosstab was forgotten to be added to the editProperties function