### PR TITLE
[18088] *Add global setup for Page Setup - Paper Size

### DIFF
--- a/OpenRPT/renderer/orprerender.cpp
+++ b/OpenRPT/renderer/orprerender.cpp
@@ -1228,6 +1228,7 @@ qreal ORPreRenderPrivate::renderSection(const ORSectionData & sectionData)
 qreal ORPreRenderPrivate::renderTextElements(QList<QPair<ORObject*,qreal>> elemList, qreal sectionHeight)
 {
   QList<TextElementSplitter> splitters;
+
   for (int i=0; i<elemList.size(); i++)
   {
     orData       dataThis;
@@ -1242,24 +1243,25 @@ qreal ORPreRenderPrivate::renderTextElements(QList<QPair<ORObject*,qreal>> elemL
   while (!splitters.isEmpty())
   {
     bool newPageRequested = false;
+
     for (int i = 0; i < splitters.size(); i++)
     {
       TextElementSplitter *splitter = &(splitters[i]);
       while (!splitter->endOfText() && !splitter->endOfPage())
       {
-        
         for (int j=i+1; j < splitters.size(); j++)
         {
           if(splitter->currentLineRect().intersects(splitters[j].currentLineRect()))
             splitters[j].adjustElementHeight(splitter->textBottomRelativePos());
-        }    
-        splitter->nextLine();
+        }
+
         addTextPrimitive(splitter->element(),
                           splitter->currentLineRect().topLeft(),
                           splitter->currentLineRect().size(),
                           splitter->element()->align,
                           splitter->currentLine(),
-                          splitter->element()->font);			 
+                          splitter->element()->font);			
+        splitter->nextLine();
       }
 
       if (splitter->textBottomRelativePos() > sectionHeight)

--- a/OpenRPT/wrtembed/documentscene.cpp
+++ b/OpenRPT/wrtembed/documentscene.cpp
@@ -115,10 +115,13 @@ void DocumentScene::initData()
     p.setColor(QColor("blue"));
     _pageMargin = addRect(0, 0, 0, 0, p);
     _pageMargin->setZValue(-1);
+    _font = handler()->sysFont(); //use system font. will be overwriten if report has a default font
+    ORGraphicsRectItem::setDefaultEntityFont(_font);
 
     if(!_pageOptions) {
       _pageOptions = new ReportPageOptions;
-      _pageOptions->setSystemDefaults();
+      _pageOptions->setPageSize(handler()->sysPageSize());
+      _pageOptions->setPortrait(handler()->sysPageOrientation() == "portrait");
       connect(_pageOptions, SIGNAL(pageOptionsChanged()), this, SLOT(pageOptionsChanged()));
     }
 }
@@ -1624,8 +1627,6 @@ QDomDocument DocumentScene::document()
     root.appendChild(_handler->databaseElt());
   }
   
-  ORGraphicsRectItem::setReadDefaultFontFalse();
-
   return doc;
 }
 

--- a/OpenRPT/wrtembed/documentscene.cpp
+++ b/OpenRPT/wrtembed/documentscene.cpp
@@ -117,8 +117,9 @@ void DocumentScene::initData()
     _pageMargin->setZValue(-1);
 
     if(!_pageOptions) {
-        _pageOptions = new ReportPageOptions;
-        connect(_pageOptions, SIGNAL(pageOptionsChanged()), this, SLOT(pageOptionsChanged()));
+      _pageOptions = new ReportPageOptions;
+      _pageOptions->setSystemDefaults();
+      connect(_pageOptions, SIGNAL(pageOptionsChanged()), this, SLOT(pageOptionsChanged()));
     }
 }
 

--- a/OpenRPT/wrtembed/editpreferences.cpp
+++ b/OpenRPT/wrtembed/editpreferences.cpp
@@ -23,6 +23,7 @@
 #include <QVariant>
 #include <QValidator>
 #include <QFontDialog>
+#include <QSettings>
 #include "data.h"
 
 EditPreferences::EditPreferences(QWidget* parent, Qt::WindowFlags fl)
@@ -50,6 +51,28 @@ EditPreferences::EditPreferences(QWidget* parent, Qt::WindowFlags fl)
             _cbLanguage->setCurrentIndex(i);
             break;
         }
+    }
+
+    //initialize combobox
+    _cbPageSize->clear();
+    _cbPageSize->addItem(tr("Letter"), "Letter");
+    _cbPageSize->addItem(tr("Legal"), "Legal");
+    _cbPageSize->addItem(tr("A4"), "A4");
+    _cbPageSize->addItem(tr("Custom"), "Custom");
+    _cbPageSize->addItem(tr("Label"), "Label");
+
+    _rbPortrait->setChecked(false);
+    _rbLandscape->setChecked(false);
+
+    QSettings settings(QSettings::UserScope, "OpenMFG.com", "OpenReports");
+    if(!settings.value("/OpenMFG/rptPageSize").toString().isEmpty())
+      _cbPageSize->setCurrentText(settings.value("/OpenMFG/rptPageSize").toString());
+    if(!settings.value("/OpenMFG/rptOrientation").toString().isEmpty())
+    {
+      if(settings.value("/OpenMFG/rptOrientation").toString()=="portrait")
+        _rbPortrait->setChecked(true);
+      if(settings.value("/OpenMFG/rptOrientation").toString()=="landscape")
+        _rbLandscape->setChecked(true);
     }
 }
 

--- a/OpenRPT/wrtembed/editpreferences.cpp
+++ b/OpenRPT/wrtembed/editpreferences.cpp
@@ -23,7 +23,6 @@
 #include <QVariant>
 #include <QValidator>
 #include <QFontDialog>
-#include <QSettings>
 #include "data.h"
 
 EditPreferences::EditPreferences(QWidget* parent, Qt::WindowFlags fl)
@@ -63,17 +62,6 @@ EditPreferences::EditPreferences(QWidget* parent, Qt::WindowFlags fl)
 
     _rbPortrait->setChecked(false);
     _rbLandscape->setChecked(false);
-
-    QSettings settings(QSettings::UserScope, "OpenMFG.com", "OpenReports");
-    if(!settings.value("/OpenMFG/rptPageSize").toString().isEmpty())
-      _cbPageSize->setCurrentText(settings.value("/OpenMFG/rptPageSize").toString());
-    if(!settings.value("/OpenMFG/rptOrientation").toString().isEmpty())
-    {
-      if(settings.value("/OpenMFG/rptOrientation").toString()=="portrait")
-        _rbPortrait->setChecked(true);
-      if(settings.value("/OpenMFG/rptOrientation").toString()=="landscape")
-        _rbLandscape->setChecked(true);
-    }
 }
 
 EditPreferences::~EditPreferences()
@@ -177,5 +165,18 @@ QFont EditPreferences::defaultFont()
 void EditPreferences::selLanguage( QString sel )
 {
     _selectedLanguage = sel;
+}
+
+void EditPreferences::setPageSize(QString ps)
+{
+   _cbPageSize->setCurrentText(ps);
+}
+
+void  EditPreferences::setPageOrientation(QString po)
+{
+  if(po=="portrait")
+    _rbPortrait->setChecked(true);
+  else
+    _rbLandscape->setChecked(true);
 }
 

--- a/OpenRPT/wrtembed/editpreferences.h
+++ b/OpenRPT/wrtembed/editpreferences.h
@@ -25,6 +25,7 @@
 
 #include "ui_editpreferences.h"
 
+
 class EditPreferences : public QDialog, public Ui::EditPreferences
 {
     Q_OBJECT
@@ -45,6 +46,8 @@ public slots:
     virtual void setSnapGrid( bool snap );
     virtual void setDefaultFont( QFont fnt );
     virtual QFont defaultFont();
+    virtual void setPageSize(QString ps);
+    virtual void setPageOrientation(QString po);
 
 protected slots:
     virtual void languageChange();

--- a/OpenRPT/wrtembed/editpreferences.ui
+++ b/OpenRPT/wrtembed/editpreferences.ui
@@ -1,4 +1,5 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <comment> * OpenRPT report writer and rendering engine
  * Copyright (C) 2001-2018 by OpenMFG, LLC
  *
@@ -17,279 +18,365 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  * Please contact info@openmfg.com with any questions on this license.</comment>
  <class>EditPreferences</class>
- <widget class="QDialog" name="EditPreferences" >
-  <property name="geometry" >
+ <widget class="QDialog" name="EditPreferences">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>462</width>
-    <height>361</height>
+    <width>514</width>
+    <height>370</height>
    </rect>
   </property>
-  <property name="sizePolicy" >
-   <sizepolicy vsizetype="MinimumExpanding" hsizetype="Preferred" >
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>Preferences</string>
   </property>
-  <layout class="QHBoxLayout" >
+  <layout class="QHBoxLayout">
    <item>
-    <layout class="QVBoxLayout" >
-     <property name="spacing" >
-      <number>0</number>
+    <widget class="QTabWidget" name="_tab">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>100</horstretch>
+       <verstretch>100</verstretch>
+      </sizepolicy>
      </property>
-     <item>
-      <layout class="QVBoxLayout" >
-       <item>
-        <layout class="QHBoxLayout" >
+     <property name="tabShape">
+      <enum>QTabWidget::Rounded</enum>
+     </property>
+     <property name="currentIndex">
+      <number>1</number>
+     </property>
+     <property name="documentMode">
+      <bool>false</bool>
+     </property>
+     <property name="tabsClosable">
+      <bool>false</bool>
+     </property>
+     <property name="movable">
+      <bool>false</bool>
+     </property>
+     <widget class="QWidget" name="_reportTab">
+      <attribute name="title">
+       <string>Report</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="0" column="0">
+        <layout class="QVBoxLayout">
          <item>
-          <widget class="QLabel" name="label" >
-           <property name="text" >
-            <string>Language :</string>
+          <layout class="QHBoxLayout">
+           <item>
+            <widget class="QLabel" name="label">
+             <property name="text">
+              <string>Language :</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+             <property name="buddy">
+              <cstring>_cbLanguage</cstring>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="_cbLanguage"/>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="_bgDefaultFont">
+           <property name="title">
+            <string>Default Font</string>
            </property>
-           <property name="alignment" >
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-           <property name="buddy" >
-            <cstring>_cbLanguage</cstring>
-           </property>
+           <layout class="QHBoxLayout">
+            <property name="spacing">
+             <number>6</number>
+            </property>
+            <property name="leftMargin">
+             <number>11</number>
+            </property>
+            <property name="topMargin">
+             <number>11</number>
+            </property>
+            <property name="rightMargin">
+             <number>11</number>
+            </property>
+            <property name="bottomMargin">
+             <number>11</number>
+            </property>
+            <item>
+             <widget class="QLineEdit" name="_leDefaultFont">
+              <property name="frame">
+               <bool>true</bool>
+              </property>
+              <property name="readOnly">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="_btnChangeFont">
+              <property name="text">
+               <string>&amp;Font...</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </widget>
          </item>
          <item>
-          <widget class="QComboBox" name="_cbLanguage" />
+          <widget class="QGroupBox" name="_gbGridOptions">
+           <property name="title">
+            <string>Grid Options</string>
+           </property>
+           <layout class="QVBoxLayout">
+            <property name="spacing">
+             <number>6</number>
+            </property>
+            <property name="leftMargin">
+             <number>11</number>
+            </property>
+            <property name="topMargin">
+             <number>11</number>
+            </property>
+            <property name="rightMargin">
+             <number>11</number>
+            </property>
+            <property name="bottomMargin">
+             <number>11</number>
+            </property>
+            <item>
+             <widget class="QCheckBox" name="_cbShowGrid">
+              <property name="text">
+               <string>Show grid</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="_cbSnapGrid">
+              <property name="text">
+               <string>Snap to grid</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="_gbGridSize">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="title">
+               <string>Grid Size Interval</string>
+              </property>
+              <layout class="QGridLayout">
+               <property name="leftMargin">
+                <number>11</number>
+               </property>
+               <property name="topMargin">
+                <number>11</number>
+               </property>
+               <property name="rightMargin">
+                <number>11</number>
+               </property>
+               <property name="bottomMargin">
+                <number>11</number>
+               </property>
+               <property name="spacing">
+                <number>6</number>
+               </property>
+               <item row="2" column="0">
+                <spacer>
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeType">
+                  <enum>QSizePolicy::MinimumExpanding</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="2" column="1">
+                <widget class="QCheckBox" name="_cbGridSymetrical">
+                 <property name="text">
+                  <string>Symetrical values</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="_lblGridSizeY">
+                 <property name="text">
+                  <string>Y Interval:</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                 <property name="buddy">
+                  <cstring>_leGridSizeY</cstring>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLineEdit" name="_leGridSizeX"/>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLineEdit" name="_leGridSizeY"/>
+               </item>
+               <item row="0" column="0">
+                <widget class="QLabel" name="_lblGridSizeX">
+                 <property name="text">
+                  <string>X Interval:</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                 <property name="buddy">
+                  <cstring>_leGridSizeX</cstring>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+           </layout>
+          </widget>
          </item>
         </layout>
        </item>
-       <item>
-        <widget class="QGroupBox" name="_bgDefaultFont" >
-         <property name="title" >
-          <string>Default Font</string>
-         </property>
-         <layout class="QHBoxLayout" >
-          <property name="spacing" >
-           <number>6</number>
-          </property>
-          <property name="leftMargin" >
-           <number>11</number>
-          </property>
-          <property name="topMargin" >
-           <number>11</number>
-          </property>
-          <property name="rightMargin" >
-           <number>11</number>
-          </property>
-          <property name="bottomMargin" >
-           <number>11</number>
-          </property>
-          <item>
-           <widget class="QLineEdit" name="_leDefaultFont" >
-            <property name="frame" >
-             <bool>true</bool>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="_systemTab">
+      <attribute name="title">
+       <string>System</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_2">
+       <item row="0" column="0">
+        <layout class="QVBoxLayout" name="verticalLayout">
+         <item>
+          <widget class="QGroupBox" name="_gbPageSetup">
+           <property name="title">
+            <string>Page Setup</string>
+           </property>
+           <widget class="QWidget" name="horizontalLayoutWidget">
+            <property name="geometry">
+             <rect>
+              <x>10</x>
+              <y>20</y>
+              <width>161</width>
+              <height>68</height>
+             </rect>
             </property>
-            <property name="readOnly" >
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="_btnChangeFont" >
-            <property name="text" >
-             <string>&amp;Font...</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="_gbGridOptions" >
-         <property name="title" >
-          <string>Grid Options</string>
-         </property>
-         <layout class="QVBoxLayout" >
-          <property name="spacing" >
-           <number>6</number>
-          </property>
-          <property name="leftMargin" >
-           <number>11</number>
-          </property>
-          <property name="topMargin" >
-           <number>11</number>
-          </property>
-          <property name="rightMargin" >
-           <number>11</number>
-          </property>
-          <property name="bottomMargin" >
-           <number>11</number>
-          </property>
-          <item>
-           <widget class="QCheckBox" name="_cbShowGrid" >
-            <property name="text" >
-             <string>Show grid</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="_cbSnapGrid" >
-            <property name="text" >
-             <string>Snap to grid</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QGroupBox" name="_gbGridSize" >
-            <property name="sizePolicy" >
-             <sizepolicy vsizetype="MinimumExpanding" hsizetype="Preferred" >
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="title" >
-             <string>Grid Size Interval</string>
-            </property>
-            <layout class="QGridLayout" >
-             <property name="leftMargin" >
-              <number>11</number>
-             </property>
-             <property name="topMargin" >
-              <number>11</number>
-             </property>
-             <property name="rightMargin" >
-              <number>11</number>
-             </property>
-             <property name="bottomMargin" >
-              <number>11</number>
-             </property>
-             <property name="horizontalSpacing" >
-              <number>6</number>
-             </property>
-             <property name="verticalSpacing" >
-              <number>6</number>
-             </property>
-             <item row="0" column="0" >
-              <widget class="QLabel" name="_lblGridSizeX" >
-               <property name="text" >
-                <string>X Interval:</string>
-               </property>
-               <property name="alignment" >
-                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-               </property>
-               <property name="buddy" >
-                <cstring>_leGridSizeX</cstring>
+            <layout class="QGridLayout" name="gridLayout_3">
+             <item row="1" column="1">
+              <widget class="QRadioButton" name="_rbPortrait">
+               <property name="text">
+                <string>Portrait</string>
                </property>
               </widget>
              </item>
-             <item row="1" column="0" >
-              <widget class="QLabel" name="_lblGridSizeY" >
-               <property name="text" >
-                <string>Y Interval:</string>
-               </property>
-               <property name="alignment" >
-                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-               </property>
-               <property name="buddy" >
-                <cstring>_leGridSizeY</cstring>
+             <item row="0" column="1">
+              <widget class="QComboBox" name="_cbPageSize"/>
+             </item>
+             <item row="0" column="0">
+              <widget class="QLabel" name="_lbSize">
+               <property name="text">
+                <string>Page Size</string>
                </property>
               </widget>
              </item>
-             <item row="0" column="1" >
-              <widget class="QLineEdit" name="_leGridSizeX" />
-             </item>
-             <item row="1" column="1" >
-              <widget class="QLineEdit" name="_leGridSizeY" />
-             </item>
-             <item row="2" column="1" >
-              <widget class="QCheckBox" name="_cbGridSymetrical" >
-               <property name="text" >
-                <string>Symetrical values</string>
+             <item row="1" column="0">
+              <widget class="QLabel" name="_lbOrientation">
+               <property name="text">
+                <string>Orientation</string>
                </property>
               </widget>
              </item>
-             <item row="2" column="0" >
-              <spacer>
-               <property name="orientation" >
-                <enum>Qt::Horizontal</enum>
+             <item row="2" column="1">
+              <widget class="QRadioButton" name="_rbLandscape">
+               <property name="text">
+                <string>Landscape</string>
                </property>
-               <property name="sizeType" >
-                <enum>QSizePolicy::MinimumExpanding</enum>
+               <property name="checkable">
+                <bool>true</bool>
                </property>
-               <property name="sizeHint" >
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
+               <property name="checked">
+                <bool>false</bool>
                </property>
-              </spacer>
+              </widget>
              </item>
             </layout>
            </widget>
-          </item>
-         </layout>
-        </widget>
+          </widget>
+         </item>
+        </layout>
        </item>
       </layout>
-     </item>
-     <item>
-      <spacer>
-       <property name="orientation" >
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeType" >
-        <enum>QSizePolicy::Expanding</enum>
-       </property>
-       <property name="sizeHint" >
-        <size>
-         <width>359</width>
-         <height>16</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
+     </widget>
+    </widget>
    </item>
    <item>
-    <layout class="QVBoxLayout" >
-     <property name="spacing" >
+    <layout class="QVBoxLayout">
+     <property name="spacing">
       <number>6</number>
      </property>
-     <property name="leftMargin" >
+     <property name="leftMargin">
       <number>0</number>
      </property>
-     <property name="topMargin" >
+     <property name="topMargin">
       <number>0</number>
      </property>
-     <property name="rightMargin" >
+     <property name="rightMargin">
       <number>0</number>
      </property>
-     <property name="bottomMargin" >
+     <property name="bottomMargin">
       <number>0</number>
      </property>
      <item>
-      <widget class="QPushButton" name="_btnOk" >
-       <property name="text" >
+      <widget class="QPushButton" name="_btnOk">
+       <property name="text">
         <string>&amp;OK</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="_btnCancel" >
-       <property name="text" >
+      <widget class="QPushButton" name="_btnCancel">
+       <property name="text">
         <string>&amp;Cancel</string>
        </property>
       </widget>
      </item>
      <item>
       <spacer>
-       <property name="orientation" >
+       <property name="orientation">
         <enum>Qt::Vertical</enum>
        </property>
-       <property name="sizeType" >
+       <property name="sizeType">
         <enum>QSizePolicy::Expanding</enum>
        </property>
-       <property name="sizeHint" >
+       <property name="sizeHint" stdset="0">
         <size>
          <width>20</width>
          <height>40</height>
@@ -301,7 +388,7 @@
    </item>
   </layout>
  </widget>
- <layoutdefault spacing="6" margin="11" />
+ <layoutdefault spacing="6" margin="11"/>
  <resources/>
  <connections>
   <connection>
@@ -310,11 +397,11 @@
    <receiver>EditPreferences</receiver>
    <slot>reject()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>20</x>
      <y>20</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
     </hint>
@@ -326,11 +413,11 @@
    <receiver>EditPreferences</receiver>
    <slot>accept()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>20</x>
      <y>20</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
     </hint>
@@ -342,11 +429,11 @@
    <receiver>_lblGridSizeY</receiver>
    <slot>setDisabled(bool)</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>20</x>
      <y>20</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
     </hint>
@@ -358,11 +445,11 @@
    <receiver>_leGridSizeY</receiver>
    <slot>setDisabled(bool)</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>20</x>
      <y>20</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
     </hint>

--- a/OpenRPT/wrtembed/graphicsitems.cpp
+++ b/OpenRPT/wrtembed/graphicsitems.cpp
@@ -709,27 +709,16 @@ void ORGraphicsRectItem::buildXMLCommon(QDomDocument & doc, QDomElement & entity
 }
 
 
-bool ORGraphicsRectItem::_readDefaultFont = false;
 QFont ORGraphicsRectItem::_defaultFont = QFont();
 
 QFont ORGraphicsRectItem::getDefaultEntityFont()
 {
-  if(!_readDefaultFont)
-  {
-    QSettings settings(QSettings::UserScope, "OpenMFG.com", "OpenReports");
-    _defaultFont.fromString(settings.value("/OpenMFG/rwDefaultEntityFont",_defaultFont.toString()).toString());
-    _readDefaultFont = true;
-	QFontDatabase fdb;
-  }
   return _defaultFont;
 }
 
 void ORGraphicsRectItem::setDefaultEntityFont(const QFont & f)
 {
   _defaultFont = f;
-  QSettings settings(QSettings::UserScope, "OpenMFG.com", "OpenReports");
-  settings.setValue("/OpenMFG/rwDefaultEntityFont", _defaultFont.toString());
-  _readDefaultFont = true;
 }
 
 void ORGraphicsRectItem::setRotation(qreal angle) 

--- a/OpenRPT/wrtembed/graphicsitems.h
+++ b/OpenRPT/wrtembed/graphicsitems.h
@@ -82,7 +82,6 @@ class ORGraphicsRectItem : public QGraphicsRectItem
 
     static QFont getDefaultEntityFont();
     static void  setDefaultEntityFont(const QFont &);
-	static void setReadDefaultFontFalse(){_readDefaultFont = false;}
 
     virtual void properties(QWidget * parent = 0);
     void borderProperties(QWidget * parent = 0);
@@ -116,7 +115,6 @@ class ORGraphicsRectItem : public QGraphicsRectItem
     QPen            _border;
 
 	bool			_moved;
-    static bool _readDefaultFont;
     static QFont _defaultFont;
 };
 

--- a/OpenRPT/wrtembed/reportgridoptions.cpp
+++ b/OpenRPT/wrtembed/reportgridoptions.cpp
@@ -23,7 +23,6 @@
 // qt
 #include <QPoint>
 #include <QPointF>
-#include <QSettings>
 #include <QDebug>
 
 #include <math.h>
@@ -37,20 +36,13 @@ extern int dpiY;
 ReportGridOptions::ReportGridOptions(int rdx, int rdy, QObject * parent, const char * name)
   : QObject(parent) {
     if(name)
-      setObjectName(name);
-    QSettings settings(QSettings::UserScope, "OpenMFG.com", "OpenReports");
-    show_grid = settings.value("/OpenMFG/rwShowGrid", false).toBool();
-    snap_grid = settings.value("/OpenMFG/rwSnapGrid", false).toBool();
+    setObjectName(name);
     _realDpiX = rdx;
     _realDpiY = rdy;
-    setXInterval(settings.value("/OpenMFG/rwXGridInterval",0.05).toDouble());
-    setYInterval(settings.value("/OpenMFG/rwYGridInterval",0.05).toDouble());
 }
 
 void ReportGridOptions::setVisible(bool v) {
     show_grid = v;
-    QSettings settings(QSettings::UserScope, "OpenMFG.com", "OpenReports");
-    settings.setValue("/OpenMFG/rwShowGrid", show_grid);
     emit gridOptionsChanged();
 }
 
@@ -60,8 +52,6 @@ bool ReportGridOptions::isVisible() {
 
 void ReportGridOptions::setSnap(bool yes) {
     snap_grid = yes;
-    QSettings settings(QSettings::UserScope, "OpenMFG.com", "OpenReports");
-    settings.setValue("/OpenMFG/rwSnapGrid", snap_grid);
     emit gridOptionsChanged();
 }
 
@@ -104,8 +94,6 @@ void ReportGridOptions::hide() {
 
 void ReportGridOptions::setXInterval(double i) {
     x_interval = i;
-    QSettings settings(QSettings::UserScope, "OpenMFG.com", "OpenReports");
-    settings.setValue("/OpenMFG/rwXGridInterval", x_interval);
     double d = _realDpiX * x_interval;
     double di = ((d - floor(d)) < 0.5 ? floor(d) : (floor(d) + 1.0) );
     dpiX = (int)((di / x_interval) + 0.01);
@@ -116,8 +104,6 @@ double ReportGridOptions::xInterval() {
 }
 void ReportGridOptions::setYInterval(double i) {
     y_interval = i;
-    QSettings settings(QSettings::UserScope, "OpenMFG.com", "OpenReports");
-    settings.setValue("/OpenMFG/rwYGridInterval", y_interval);
     double d = _realDpiY * y_interval;
     double di = ((d - floor(d)) < 0.5 ? floor(d) : floor(d) + 1.0 );
     dpiY = (int)((di / y_interval) + 0.01);

--- a/OpenRPT/wrtembed/reporthandler.cpp
+++ b/OpenRPT/wrtembed/reporthandler.cpp
@@ -1211,12 +1211,23 @@ void ReportHandler::editPreferences()
     dlgPref->setGridSize(gridOptions->xInterval() ,gridOptions->yInterval());
     if(dlgPref->exec() == QDialog::Accepted)
     {
+      //report level 
       ORGraphicsRectItem::setDefaultEntityFont(dlgPref->defaultFont());
       gridShowAction->setChecked(dlgPref->showGrid());
       gridSnapAction->setChecked(dlgPref->snapGrid());
       gridOptions->setXInterval(dlgPref->gridSizeX());
       gridOptions->setYInterval(dlgPref->gridSizeY());
       QString newLanguage = dlgPref->selectedLanguage();
+
+      //system level
+      QSettings settings(QSettings::UserScope, "OpenMFG.com", "OpenReports");
+      settings.setValue("/OpenMFG/rptPageSize", dlgPref->_cbPageSize->currentText());
+      if(dlgPref->_rbPortrait->isChecked())
+        settings.setValue("/OpenMFG/rptOrientation", "portrait");
+      if(dlgPref->_rbLandscape->isChecked())
+        settings.setValue("/OpenMFG/rptOrientation", "landscape");
+
+
       if(newLanguage != OpenRPT::languages.selectedTitle())
       {
         QMessageBox::information(dlgPref, QString(tr("Language: %1").arg(newLanguage)), tr("The language change will take effect the next time the report writer will be run."));

--- a/OpenRPT/wrtembed/reporthandler.cpp
+++ b/OpenRPT/wrtembed/reporthandler.cpp
@@ -217,6 +217,7 @@ ReportHandler::ReportHandler(QObject * parent, const char * name)
   gridOptions = new ReportGridOptions(qApp->desktop()->logicalDpiX(),
                                       qApp->desktop()->logicalDpiY(),
                                       this, "grid options");
+  getSysPreferences();
   sectionData = new ReportWriterSectionData();
 
   grpDoc = new QActionGroup(this);
@@ -426,6 +427,7 @@ ReportHandler::ReportHandler(QObject * parent, const char * name)
 
 ReportHandler::~ReportHandler()
 {
+    setSysPreferences();
     if (sectionData != 0)
         delete sectionData;
 }
@@ -1205,7 +1207,15 @@ void ReportHandler::editPreferences()
   EditPreferences * dlgPref = new EditPreferences(0);
   if(dlgPref)
   {
-    dlgPref->setDefaultFont(QFont(ORGraphicsRectItem::getDefaultEntityFont()));
+    if(gwList.count()>0)
+    {
+      DocumentWindow * gw = activeDocumentWindow();
+      dlgPref->setDefaultFont(gw->_scene->getFont()); 
+    }
+    else
+      dlgPref->setDefaultFont(_sysFont); 
+    dlgPref->setPageSize(_sysPageSize);
+    dlgPref->setPageOrientation(_sysPageOrientation);
     dlgPref->setShowGrid(gridOptions->isVisible());
     dlgPref->setSnapGrid(gridOptions->isSnap());
     dlgPref->setGridSize(gridOptions->xInterval() ,gridOptions->yInterval());
@@ -1220,12 +1230,11 @@ void ReportHandler::editPreferences()
       QString newLanguage = dlgPref->selectedLanguage();
 
       //system level
-      QSettings settings(QSettings::UserScope, "OpenMFG.com", "OpenReports");
-      settings.setValue("/OpenMFG/rptPageSize", dlgPref->_cbPageSize->currentText());
+      _sysPageSize = dlgPref->_cbPageSize->currentText();
       if(dlgPref->_rbPortrait->isChecked())
-        settings.setValue("/OpenMFG/rptOrientation", "portrait");
+        _sysPageOrientation = "portrait";
       if(dlgPref->_rbLandscape->isChecked())
-        settings.setValue("/OpenMFG/rptOrientation", "landscape");
+        _sysPageOrientation = "landscape";
 
 
       if(newLanguage != OpenRPT::languages.selectedTitle())
@@ -1522,7 +1531,6 @@ void ReportHandler::removeReportWindow(QObject * obj)
   if(gw)
     gwList.removeAll(gw);
   
-  qDebug() << "\nremoved report window";
   // update the default font 
   gw = activeDocumentWindow();
   if (gwList.size()>0) 
@@ -2488,6 +2496,37 @@ void ReportHandler::setFontStyle(bool v)
   if(o)
     o->setChecked(v);
 }
+
+void  ReportHandler::getSysPreferences()
+{
+  QSettings settings(QSettings::UserScope, "OpenMFG.com", "OpenReports");
+  _sysPageSize = settings.value("/OpenMFG/rptPageSize","Letter").toString();
+  _sysPageOrientation = settings.value("/OpenMFG/rptOrientation","portrait").toString();
+  if(settings.value("/OpenMFG/defaultFont").toString().isEmpty())
+    _sysFont = QFont();
+  else
+    QFont(settings.value("/OpenMFG/defaultFont").toString());
+
+  gridOptions->setVisible(settings.value("/OpenMFG/rwShowGrid", false).toBool());
+  gridOptions->setSnap(settings.value("/OpenMFG/rwSnapGrid", false).toBool());
+  gridOptions->setXInterval(settings.value("/OpenMFG/rwXGridInterval",0.05).toDouble());
+  gridOptions->setYInterval(settings.value("/OpenMFG/rwYGridInterval",0.05).toDouble());
+}
+
+void  ReportHandler::setSysPreferences()
+{
+  QSettings settings(QSettings::UserScope, "OpenMFG.com", "OpenReports");
+  settings.setValue("/OpenMFG/rptPageSize", _sysPageSize);
+  settings.setValue("/OpenMFG/rptOrientation", _sysPageOrientation);
+  settings.setValue("/OpenMFG/defaultFont", _sysFont);
+
+  settings.setValue("/OpenMFG/rwShowGrid", gridOptions->isVisible());
+  settings.setValue("/OpenMFG/rwSnapGrid", gridOptions->isSnap());
+  settings.setValue("/OpenMFG/rwXGridInterval", gridOptions->xInterval());
+  settings.setValue("/OpenMFG/rwYGridInterval", gridOptions->yInterval());
+
+}
+
 
 void ReportHandler::loadMemDB(const QString &filename, const QDomNode &it)
 {

--- a/OpenRPT/wrtembed/reporthandler.h
+++ b/OpenRPT/wrtembed/reporthandler.h
@@ -167,6 +167,13 @@ class ReportHandler : public QObject {
         void setFontWeight(bool v);
         void setFontStyle(bool v);
 
+        //system pref functions
+        void    getSysPreferences(); //reads from QSettings
+        void    setSysPreferences(); //saves to QSettings
+        QFont   sysFont(){return _sysFont;}
+        QString sysPageSize(){return _sysPageSize;}
+        QString sysPageOrientation(){return _sysPageOrientation;}
+
     signals:
         void messageChanged(const QString & message);
         void messageCleared();
@@ -174,8 +181,15 @@ class ReportHandler : public QObject {
         void reportsChanged(int, bool);
 
     protected:
-        ReportGridOptions * gridOptions;
         ReportWriterSectionData * sectionData;
+        
+        // system preferences
+        ReportGridOptions * gridOptions;
+        QString             _sysPageSize;
+        QString             _sysPageOrientation;
+        QFont               _sysFont;
+
+        //report preferences
 
         unsigned int selectionCount();
 

--- a/common/reportpageoptions.cpp
+++ b/common/reportpageoptions.cpp
@@ -18,6 +18,7 @@
  * Please contact info@openmfg.com with any questions on this license.
  */
 
+#include <QSettings>
 #include "reportpageoptions.h"
 
 ReportPageOptions::ReportPageOptions()
@@ -187,4 +188,15 @@ void ReportPageOptions::setLabelType(const QString & type)
 
   _labelType = type;
   emit pageOptionsChanged();
+}
+
+void ReportPageOptions::setSystemDefaults()
+{
+  QSettings settings(QSettings::UserScope, "OpenMFG.com", "OpenReports");
+  if(!settings.value("/OpenMFG/rptPageSize").toString().isEmpty())
+    setPageSize(settings.value("/OpenMFG/rptPageSize").toString());
+  if(settings.value("/OpenMFG/rptOrientation").toString()=="portrait" )
+    setPortrait(true);
+  if(settings.value("/OpenMFG/rptOrientation").toString()=="landscape" )
+    setPortrait(false);
 }

--- a/common/reportpageoptions.cpp
+++ b/common/reportpageoptions.cpp
@@ -18,7 +18,6 @@
  * Please contact info@openmfg.com with any questions on this license.
  */
 
-#include <QSettings>
 #include "reportpageoptions.h"
 
 ReportPageOptions::ReportPageOptions()
@@ -188,15 +187,4 @@ void ReportPageOptions::setLabelType(const QString & type)
 
   _labelType = type;
   emit pageOptionsChanged();
-}
-
-void ReportPageOptions::setSystemDefaults()
-{
-  QSettings settings(QSettings::UserScope, "OpenMFG.com", "OpenReports");
-  if(!settings.value("/OpenMFG/rptPageSize").toString().isEmpty())
-    setPageSize(settings.value("/OpenMFG/rptPageSize").toString());
-  if(settings.value("/OpenMFG/rptOrientation").toString()=="portrait" )
-    setPortrait(true);
-  if(settings.value("/OpenMFG/rptOrientation").toString()=="landscape" )
-    setPortrait(false);
 }

--- a/common/reportpageoptions.h
+++ b/common/reportpageoptions.h
@@ -62,6 +62,8 @@ class ReportPageOptions : public QObject
     void setLabelType(const QString &);
     const QString & getLabelType() const;
 
+    void setSystemDefaults();
+
   signals:
     void pageOptionsChanged();
 

--- a/common/reportpageoptions.h
+++ b/common/reportpageoptions.h
@@ -61,9 +61,7 @@ class ReportPageOptions : public QObject
 
     void setLabelType(const QString &);
     const QString & getLabelType() const;
-
-    void setSystemDefaults();
-
+    
   signals:
     void pageOptionsChanged();
 


### PR DESCRIPTION
- added `report` and `system` tabs to editPreferences.ui (edit>preferences menu item)

Everything on the `system` tab is saved using QSettings, but doesn't affect currently open reports.
The `local` preferences -that are stored into `_pageOptions`- are the ones that affect the current report
The `system` preferences are only applied to new documents only (don't affect documents that are loaded from the DB or filesystem)