### PR TITLE
[28212] simplify dialog by removing 'reached end of doc' message

### DIFF
--- a/MetaSQL/mqledit.cpp
+++ b/MetaSQL/mqledit.cpp
@@ -65,6 +65,8 @@ MQLEdit::MQLEdit(QWidget* parent, Qt::WindowFlags fl)
   _document = _text->document();
   _document->setDefaultFont(QFont("Courier"));
 
+  editFindAction->setShortcut(QKeySequence::Find);
+
   connect(_document,     SIGNAL(modificationChanged(bool)), this, SLOT(setWindowModified(bool)));
   connect(editFindAction,              SIGNAL(triggered()), this, SLOT(editFind()));
   connect(fileDatabaseConnectAction,   SIGNAL(triggered()), this, SLOT(fileDatabaseConnect()));

--- a/MetaSQL/mqledit.ui
+++ b/MetaSQL/mqledit.ui
@@ -308,9 +308,7 @@
    <property name="iconText">
     <string>Find</string>
    </property>
-   <property name="shortcut">
-    <string>Ctrl+F</string>
-   </property>
+   
   </action>
   <action name="helpMqlEditorAction">
    <property name="text">

--- a/common/finddialog.cpp
+++ b/common/finddialog.cpp
@@ -52,11 +52,6 @@ void FindDialog::setTextEdit(QTextEdit* t)
   _leSearch->setText(_text->textCursor().selectedText()); //populate search lineedit if user has highlighted text
 }
 
-void FindDialog::setWarningVisible(bool value)
-{
-  return _lbWarning->setVisible(value);
-}
-
 void FindDialog::sClose()
 {
   reject();
@@ -64,15 +59,9 @@ void FindDialog::sClose()
 
 void FindDialog::sFind()
 {
-  if (_lbWarning->isVisible())
-  {
-    setWarningVisible(false);
-    sMoveCursorToStart();
-  }
-  
   QString term = _leSearch->text();
   if(!_text->find(term))
-    setWarningVisible(true);    
+    sMoveCursorToStart();    
 }
 
 void FindDialog::sMoveCursorToStart()

--- a/common/finddialog.cpp
+++ b/common/finddialog.cpp
@@ -30,7 +30,8 @@ FindDialog::FindDialog(QWidget* parent)
   setupUi(this);
 
   _lbWarning->setVisible(false);
-  connect(_btnFind,     SIGNAL(clicked()),           this,   SLOT(sFind()));
+  connect(_btnNext,     SIGNAL(clicked()),           this,   SLOT(sFind()));
+  connect(_btnPrev,     SIGNAL(clicked()),           this,   SLOT(sFindPrev()));
   connect(_leSearch,    SIGNAL(returnPressed()),     this,   SLOT(sFind()));
   connect(_btnClose,    SIGNAL(clicked()),           this,   SLOT(sClose()));
 }
@@ -57,11 +58,46 @@ void FindDialog::sClose()
   reject();
 }
 
-void FindDialog::sFind()
+void FindDialog::sFindPrev()
 {
-  QString term = _leSearch->text();
-  if(!_text->find(term))
-    sMoveCursorToStart();    
+  sFind(true);
+}
+#pragma comment(linker,"/SUBSYSTEM:CONSOLE")
+void FindDialog::sFind(bool backwards)
+{
+  sSetWarning();
+  _leSearch->setStyleSheet( QString( "background-color: white"));
+  // determine flags
+  QTextDocument::FindFlags flags ;
+  if(_cbMatchCase->isChecked())
+    flags = flags | QTextDocument::FindCaseSensitively;
+  if(_cbMatchWord->isChecked())
+    flags = flags | QTextDocument::FindWholeWords;
+  if(backwards)
+    flags = flags | QTextDocument::FindBackward;
+  
+  if(_cbRegex->isChecked())
+  {
+    QRegExp term = QRegExp(_leSearch->text());
+    if(!_text->find(term,flags))
+      _leSearch->setStyleSheet( QString( "background-color: red"));
+  }
+  else
+  {
+    QString term = _leSearch->text();
+     if(!_text->find(term,flags))
+     {
+       _leSearch->setStyleSheet( QString( "background-color: red"));
+     }
+  }  
+  if( _text->textCursor().atEnd())
+  {
+    sSetWarning(true);
+    if(_cbWrapAround->isChecked())
+      sMoveCursorToStart();
+  }
+     
+     
 }
 
 void FindDialog::sMoveCursorToStart()
@@ -69,4 +105,9 @@ void FindDialog::sMoveCursorToStart()
   QTextCursor c = _text->textCursor();
   c.movePosition(QTextCursor::Start, QTextCursor::MoveAnchor,1);
   _text->setTextCursor(c);
+}
+
+void FindDialog::sSetWarning(bool set)
+{
+  _lbWarning->setVisible(set);
 }

--- a/common/finddialog.cpp
+++ b/common/finddialog.cpp
@@ -126,6 +126,10 @@ void FindDialog::sFind()
     _lbCount->setText("No matches");
     return;
   }
+
+  /* There is a special case in which backwards search skips matches. This is seen in: 
+  https://bugreports.qt.io/browse/QTBUG-48035
+  This seems like a rare case to fall into */
   
   if(_cbRegex->isChecked())
   {

--- a/common/finddialog.h
+++ b/common/finddialog.h
@@ -34,20 +34,33 @@ class FindDialog : public QDialog, public Ui::Find
 public:
     FindDialog(QWidget* parent = 0);
     ~FindDialog();
-
+    void show();
 
 public slots:
   void languageChange();
   void setTextEdit(QTextEdit* t);
   void sClose();
+  void sCountMatches();
   void sFindPrev();
-  void sFind(bool backwards = 0);
-  void sMoveCursorToStart();
-  void sSetWarning(bool set = 0);  
+  void sFind();
+  void sMoveCursorTo(int pos);
+  void sSetFlags();
+  void sSetWarning(bool set = 0); 
+  void sSearchChanged(); 
 protected slots:
+
+protected:
+  static bool _matchCase;
+  static bool _matchWord;
+  static bool _regex;
+  static bool _wrapAround;
     
 private:
   QTextEdit* _text;
+  bool _searchChanged;
+  bool _reverseSearch;
+  QList<int> _matches;
+  QTextDocument::FindFlags flags;
     
 };
 

--- a/common/finddialog.h
+++ b/common/finddialog.h
@@ -39,7 +39,6 @@ public:
 public slots:
   void languageChange();
   void setTextEdit(QTextEdit* t);
-  void sClose();
   void sCountMatches();
   void sFindPrev();
   void sFind();

--- a/common/finddialog.h
+++ b/common/finddialog.h
@@ -39,7 +39,6 @@ public:
 public slots:
   void languageChange();
   void setTextEdit(QTextEdit* t);
-  void setWarningVisible(bool set);
   void sClose();
   void sFind();
   void sMoveCursorToStart();

--- a/common/finddialog.h
+++ b/common/finddialog.h
@@ -40,9 +40,10 @@ public slots:
   void languageChange();
   void setTextEdit(QTextEdit* t);
   void sClose();
-  void sFind();
+  void sFindPrev();
+  void sFind(bool backwards = 0);
   void sMoveCursorToStart();
-    
+  void sSetWarning(bool set = 0);  
 protected slots:
     
 private:

--- a/common/finddialog.ui
+++ b/common/finddialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>294</width>
-    <height>80</height>
+    <width>461</width>
+    <height>225</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,6 +16,78 @@
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
     <layout class="QGridLayout" name="gridLayout">
+     <item row="4" column="1">
+      <widget class="QCheckBox" name="_cbMatchWord">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QCheckBox" name="_cbRegex">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="4">
+      <widget class="QPushButton" name="_btnClose">
+       <property name="text">
+        <string>Close</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QCheckBox" name="_cbMatchCase">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="_lbMatchCase">
+       <property name="text">
+        <string>Match Case</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="_lbMatchWord">
+       <property name="text">
+        <string>Match whole word</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="_lbRegex">
+       <property name="text">
+        <string>Use regex</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="_lbWrapAround">
+       <property name="text">
+        <string>Wrap around</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="QCheckBox" name="_cbWrapAround">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="5" rowspan="2">
+      <layout class="QVBoxLayout" name="verticalLayout"/>
+     </item>
+     <item row="0" column="2">
+      <widget class="QLineEdit" name="_leSearch"/>
+     </item>
      <item row="0" column="0">
       <widget class="QLabel" name="_lbSearch">
        <property name="font">
@@ -28,32 +100,12 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="2">
-      <widget class="QLineEdit" name="_leSearch"/>
-     </item>
-     <item row="0" column="4" rowspan="2">
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <item>
-        <widget class="QPushButton" name="_btnFind">
-         <property name="text">
-          <string>Find</string>
-         </property>
-         <property name="autoDefault">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="_btnClose">
-         <property name="text">
-          <string>Close</string>
-         </property>
-         <property name="autoDefault">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-      </layout>
+     <item row="1" column="2">
+      <widget class="QLabel" name="_lbWarning">
+       <property name="text">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;End of Document&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+      </widget>
      </item>
      <item row="0" column="3">
       <spacer name="horizontalSpacer">
@@ -68,10 +120,17 @@
        </property>
       </spacer>
      </item>
-     <item row="1" column="2">
-      <widget class="QLabel" name="_lbWarning">
+     <item row="0" column="4">
+      <widget class="QPushButton" name="_btnNext">
        <property name="text">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;No matches found&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>Next</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="4">
+      <widget class="QPushButton" name="_btnPrev">
+       <property name="text">
+        <string>Prev</string>
        </property>
       </widget>
      </item>
@@ -94,8 +153,6 @@
  </widget>
  <tabstops>
   <tabstop>_leSearch</tabstop>
-  <tabstop>_btnFind</tabstop>
-  <tabstop>_btnClose</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/common/finddialog.ui
+++ b/common/finddialog.ui
@@ -6,87 +6,100 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>461</width>
-    <height>225</height>
+    <width>385</width>
+    <height>210</height>
    </rect>
+  </property>
+  <property name="focusPolicy">
+   <enum>Qt::NoFocus</enum>
   </property>
   <property name="windowTitle">
    <string>Find</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
-   <item>
-    <layout class="QGridLayout" name="gridLayout">
-     <item row="4" column="1">
-      <widget class="QCheckBox" name="_cbMatchWord">
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="0" column="2">
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QPushButton" name="_btnNext">
        <property name="text">
-        <string/>
+        <string>Next</string>
+       </property>
+       <property name="autoDefault">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
-      <widget class="QCheckBox" name="_cbRegex">
+     <item>
+      <widget class="QPushButton" name="_btnPrev">
        <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="4">
-      <widget class="QPushButton" name="_btnClose">
-       <property name="text">
-        <string>Close</string>
+        <string>Prev</string>
        </property>
        <property name="autoDefault">
         <bool>false</bool>
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
-      <widget class="QCheckBox" name="_cbMatchCase">
-       <property name="text">
-        <string/>
+     <item>
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
        </property>
-      </widget>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
      </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="_lbMatchCase">
+    </layout>
+   </item>
+   <item row="0" column="0">
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="_leSearch"/>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="_lbWarning">
        <property name="text">
-        <string>Match Case</string>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;End of Document&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
       </widget>
      </item>
      <item row="4" column="0">
-      <widget class="QLabel" name="_lbMatchWord">
-       <property name="text">
-        <string>Match whole word</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="0">
       <widget class="QLabel" name="_lbRegex">
        <property name="text">
         <string>Use regex</string>
        </property>
       </widget>
      </item>
-     <item row="6" column="0">
-      <widget class="QLabel" name="_lbWrapAround">
-       <property name="text">
-        <string>Wrap around</string>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="1">
-      <widget class="QCheckBox" name="_cbWrapAround">
+     <item row="3" column="1">
+      <widget class="QCheckBox" name="_cbMatchWord">
        <property name="text">
         <string/>
        </property>
       </widget>
      </item>
-     <item row="0" column="5" rowspan="2">
-      <layout class="QVBoxLayout" name="verticalLayout"/>
+     <item row="4" column="1">
+      <widget class="QCheckBox" name="_cbRegex">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
      </item>
-     <item row="0" column="2">
-      <widget class="QLineEdit" name="_leSearch"/>
+     <item row="3" column="0">
+      <widget class="QLabel" name="_lbMatchWord">
+       <property name="text">
+        <string>Match whole word</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="_lbMatchCase">
+       <property name="text">
+        <string>Match Case</string>
+       </property>
+      </widget>
      </item>
      <item row="0" column="0">
       <widget class="QLabel" name="_lbSearch">
@@ -100,44 +113,51 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="2">
-      <widget class="QLabel" name="_lbWarning">
+     <item row="1" column="1">
+      <widget class="QLabel" name="_lbCount">
        <property name="text">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;End of Document&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string/>
        </property>
       </widget>
      </item>
-     <item row="0" column="3">
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="0" column="4">
-      <widget class="QPushButton" name="_btnNext">
+     <item row="2" column="1">
+      <widget class="QCheckBox" name="_cbMatchCase">
        <property name="text">
-        <string>Next</string>
+        <string/>
        </property>
       </widget>
      </item>
-     <item row="1" column="4">
-      <widget class="QPushButton" name="_btnPrev">
+     <item row="5" column="0">
+      <widget class="QLabel" name="_lbWrapAround">
        <property name="text">
-        <string>Prev</string>
+        <string>Wrap around</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QCheckBox" name="_cbWrapAround">
+       <property name="text">
+        <string/>
        </property>
       </widget>
      </item>
     </layout>
    </item>
-   <item>
-    <spacer name="verticalSpacer">
+   <item row="0" column="1">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="1" column="0">
+    <spacer name="verticalSpacer_3">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
@@ -149,10 +169,27 @@
      </property>
     </spacer>
    </item>
+   <item row="2" column="2">
+    <widget class="QPushButton" name="_btnClose">
+     <property name="text">
+      <string>Close</string>
+     </property>
+     <property name="autoDefault">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <tabstops>
   <tabstop>_leSearch</tabstop>
+  <tabstop>_btnNext</tabstop>
+  <tabstop>_btnPrev</tabstop>
+  <tabstop>_cbMatchCase</tabstop>
+  <tabstop>_cbMatchWord</tabstop>
+  <tabstop>_cbRegex</tabstop>
+  <tabstop>_cbWrapAround</tabstop>
+  <tabstop>_btnClose</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
Checked ZenQ's concerns. Tested and confirmed that the search uses the current cursor position.
After the finddialog window is closed, the last match found from the search remains highlighted. this behaviour is acceptable.
