### PR TITLE
[33687] MetaSQL Editor icons not displaying

### DIFF
--- a/MetaSQL/mqledit.cpp
+++ b/MetaSQL/mqledit.cpp
@@ -58,7 +58,8 @@ MQLEdit::MQLEdit(QWidget* parent, Qt::WindowFlags fl)
     : QWidget(parent, fl)
 {
   setupUi(this);
-
+  Q_INIT_RESOURCE(OpenRPTMetaSQL);
+  
   if (OpenRPT::name.isEmpty())
     OpenRPT::name = tr("MetaSQL Editor");
 


### PR DESCRIPTION
This was found as part of ZenQ's testing of this incident, so I will just use the same incdt number
The metasql resources were not initialized
Issue should be fixed for Windows and Mac