### PR TITLE
[14628] EAN13/8 and UPC-A/E barcodes don't render with bad input

### DIFF
--- a/OpenRPT/renderer/orprerender.cpp
+++ b/OpenRPT/renderer/orprerender.cpp
@@ -976,7 +976,7 @@ qreal ORPreRenderPrivate::renderSection(const ORSectionData & sectionData)
       orData       dataThis;
       populateData(bc->data, dataThis);
       bool format = (bc->format == "ean8") || (bc->format == "ean13") || (bc->format == "upc-a") || (bc->format == "upc-e");
-      if(dataThis.getValue()=="" && format)
+      if(dataThis.getValue().isNull() && format)
         addTextPrimitive(elemThis, pos, size, 0, bc->format + ": NULL", QFont(), "red");
       else
       {


### PR DESCRIPTION
display a message that alerts user that barcode column result is null
This is done only for ean13/8 and upv-a/e