### PR TITLE
[34696] display error message when user lacks adequate privileges to login

### DIFF
--- a/common/login.cpp
+++ b/common/login.cpp
@@ -210,7 +210,13 @@ void login::sLogin()
     return;
   }
 
-  QSqlQuery().exec(getSqlFromTag("fmt05", db.driverName()));
+  QSqlQuery q(getSqlFromTag("fmt05", db.driverName()));
+  if(q.lastError().isValid())
+  {
+    QMessageBox::warning( this, tr("Inadequate Priviliges"),
+                          tr( "%1"  ).arg(q.lastError().databaseText()));
+    return;
+  }
 
   if (_splash)
   {


### PR DESCRIPTION
added a `QMessageBox::warning()` to inform user that he lacks permission to access certain tables