### PR TITLE
OpenRPT crashes when label editor tries to retrieve a query for non existent querySource

### DIFF
--- a/OpenRPT/wrtembed/labeleditor.cpp
+++ b/OpenRPT/wrtembed/labeleditor.cpp
@@ -139,12 +139,12 @@ QString LabelEditor::getQueryResult(QString str)
   }
   
   if(qry=="Context Query")
-	return QString("");
+	return QString();
    
   QSqlDatabase db = QSqlDatabase::database();
   if (!qry.isEmpty() && db.isOpen())
   {
-    if(!ds->qsList->get(qry)) //check if querysource name is valid
+    if(ds->qsList->get(qry)) //check if querysource name is valid
     {
       MetaSQLQuery mql = MetaSQLQuery(ds->qsList->get(qry)->query());
       xqry = mql.toQuery(plist,QSqlDatabase::database(),true);
@@ -152,7 +152,7 @@ QString LabelEditor::getQueryResult(QString str)
       result = xqry.value(col).toString();
     }
     else 
-      return QString("");
+      return QString();
   }
   
   return result;

--- a/OpenRPT/wrtembed/labeleditor.cpp
+++ b/OpenRPT/wrtembed/labeleditor.cpp
@@ -144,6 +144,8 @@ QString LabelEditor::getQueryResult(QString str)
   QSqlDatabase db = QSqlDatabase::database();
   if (!qry.isEmpty() && db.isOpen())
   {
+    if(ds->qsList->get(qry)==0) //check if querysource name is valid
+      return 0;
 	MetaSQLQuery mql = MetaSQLQuery(ds->qsList->get(qry)->query());
 	xqry = mql.toQuery(plist,QSqlDatabase::database(),true);
 	xqry.first();

--- a/OpenRPT/wrtembed/labeleditor.cpp
+++ b/OpenRPT/wrtembed/labeleditor.cpp
@@ -139,17 +139,20 @@ QString LabelEditor::getQueryResult(QString str)
   }
   
   if(qry=="Context Query")
-	return NULL;
+	return QString("");
    
   QSqlDatabase db = QSqlDatabase::database();
   if (!qry.isEmpty() && db.isOpen())
   {
-    if(ds->qsList->get(qry)==0) //check if querysource name is valid
-      return 0;
-	MetaSQLQuery mql = MetaSQLQuery(ds->qsList->get(qry)->query());
-	xqry = mql.toQuery(plist,QSqlDatabase::database(),true);
-	xqry.first();
-	result = xqry.value(col).toString();
+    if(!ds->qsList->get(qry)) //check if querysource name is valid
+    {
+      MetaSQLQuery mql = MetaSQLQuery(ds->qsList->get(qry)->query());
+      xqry = mql.toQuery(plist,QSqlDatabase::database(),true);
+      xqry.first();
+      result = xqry.value(col).toString();
+    }
+    else 
+      return QString("");
   }
   
   return result;


### PR DESCRIPTION
Bug found by David B.
Fix is a simple check you see if `ds->qsList->get(qry)` returns 0 or a valid querySource