### PR TITLE
By default: Do not reclaim the space taken up by null fields

### DIFF
--- a/OpenRPT/renderer/orprerender.cpp
+++ b/OpenRPT/renderer/orprerender.cpp
@@ -881,7 +881,7 @@ qreal ORPreRenderPrivate::renderSection(const ORSectionData & sectionData)
             QString text = evaluateField(elemThis->toField());
 			if (!text.isEmpty())
 			  addTextPrimitive(elemThis, QPointF(x, y), size, f->align, text, f->font); 
-			else
+			else if(!f->doNotCollapse)
 			{
 			  int horizontalStatus = 0;
 			  int objCnt = 1;

--- a/OpenRPT/renderer/orprerender.cpp
+++ b/OpenRPT/renderer/orprerender.cpp
@@ -881,7 +881,7 @@ qreal ORPreRenderPrivate::renderSection(const ORSectionData & sectionData)
             QString text = evaluateField(elemThis->toField());
 			if (!text.isEmpty())
 			  addTextPrimitive(elemThis, QPointF(x, y), size, f->align, text, f->font); 
-			else if(!f->doNotCollapse)
+			else if(f->collapse)
 			{
 			  int horizontalStatus = 0;
 			  int objCnt = 1;

--- a/OpenRPT/wrtembed/fieldeditor.ui
+++ b/OpenRPT/wrtembed/fieldeditor.ui
@@ -116,6 +116,9 @@
      </item>
      <item>
       <widget class="QCheckBox" name="_cbDoNotCollapse">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If the field returns NULL do not reclaaim the space&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
        <property name="text">
         <string>Do Not Collapse</string>
        </property>

--- a/OpenRPT/wrtembed/fieldeditor.ui
+++ b/OpenRPT/wrtembed/fieldeditor.ui
@@ -115,6 +115,13 @@
       </widget>
      </item>
      <item>
+      <widget class="QCheckBox" name="_cbDoNotCollapse">
+       <property name="text">
+        <string>Do Not Collapse</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QGroupBox" name="_gbFormat">
        <property name="title">
         <string>Format</string>

--- a/OpenRPT/wrtembed/fieldeditor.ui
+++ b/OpenRPT/wrtembed/fieldeditor.ui
@@ -115,12 +115,12 @@
       </widget>
      </item>
      <item>
-      <widget class="QCheckBox" name="_cbDoNotCollapse">
+      <widget class="QCheckBox" name="_cbCollapse">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If the field returns NULL do not reclaaim the space&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>If the field returns NULL reclaim the space</string>
        </property>
        <property name="text">
-        <string>Do Not Collapse</string>
+        <string>Collapse if NULL</string>
        </property>
       </widget>
      </item>

--- a/OpenRPT/wrtembed/graphicsitems.cpp
+++ b/OpenRPT/wrtembed/graphicsitems.cpp
@@ -1254,7 +1254,7 @@ ORGraphicsFieldItem::ORGraphicsFieldItem(QGraphicsItem * parent)
   _ySpacing = 0;
   _triggerPageBreak = false;
   _leftToRight = false;
-  _doNotCollapse = true;
+  _collapse = false;
 }
 
 ORGraphicsFieldItem::ORGraphicsFieldItem(const QDomNode & element, QGraphicsItem * parent)
@@ -1353,8 +1353,8 @@ ORGraphicsFieldItem::ORGraphicsFieldItem(const QDomNode & element, QGraphicsItem
         if(!node.firstChild().nodeValue().isEmpty())
             _format = node.firstChild().nodeValue();
         if(_format.length() > 0) _trackTotal = true;
-    } else if(n == "doNotCollapse"){
-        _doNotCollapse = (node.firstChild().nodeValue()=="true"?true:false);
+    } else if(n == "collapse"){
+        _collapse = true;
     }else {
       qDebug("while parsing field element encountered unknow element: %s",n.toLatin1().data());
     }
@@ -1443,11 +1443,8 @@ void ORGraphicsFieldItem::buildXML(QDomDocument & doc, QDomElement & parent)
   if(_leftToRight) {
       entity.appendChild(doc.createElement("leftToRight"));
   }
-
-  // do not collapse data
-  QDomElement dnc = doc.createElement("doNotCollapse");
-  dnc.appendChild(doc.createTextNode(doNotCollapse()?"true":"false"));;
-  entity.appendChild(dnc);
+  if(_collapse)
+    entity.appendChild(doc.createElement("collapse"));
 
   parent.appendChild(entity);
 }
@@ -1527,7 +1524,7 @@ void ORGraphicsFieldItem::properties(QWidget * parent)
   le->leYSpacing->setText(QString::number(_ySpacing));
   le->_cbPageBreak->setChecked(_triggerPageBreak);
   le->_cbLeftToRight->setChecked(_leftToRight);
-  le->_cbDoNotCollapse->setChecked(_doNotCollapse);
+  le->_cbCollapse->setChecked(_collapse);
 
   if(le->exec() == QDialog::Accepted)
   {
@@ -1574,7 +1571,7 @@ void ORGraphicsFieldItem::properties(QWidget * parent)
       setRect(0, 0, dw, dh);
       _setModified(scene(), true);
     }
-    _doNotCollapse = le->_cbDoNotCollapse->isChecked();
+    _collapse = le->_cbCollapse->isChecked();
     update();
   }
 }

--- a/OpenRPT/wrtembed/graphicsitems.cpp
+++ b/OpenRPT/wrtembed/graphicsitems.cpp
@@ -1254,6 +1254,7 @@ ORGraphicsFieldItem::ORGraphicsFieldItem(QGraphicsItem * parent)
   _ySpacing = 0;
   _triggerPageBreak = false;
   _leftToRight = false;
+  _doNotCollapse = true;
 }
 
 ORGraphicsFieldItem::ORGraphicsFieldItem(const QDomNode & element, QGraphicsItem * parent)
@@ -1352,7 +1353,9 @@ ORGraphicsFieldItem::ORGraphicsFieldItem(const QDomNode & element, QGraphicsItem
         if(!node.firstChild().nodeValue().isEmpty())
             _format = node.firstChild().nodeValue();
         if(_format.length() > 0) _trackTotal = true;
-    } else {
+    } else if(n == "doNotCollapse"){
+        _doNotCollapse = (node.firstChild().nodeValue()=="true"?true:false);
+    }else {
       qDebug("while parsing field element encountered unknow element: %s",n.toLatin1().data());
     }
   }
@@ -1441,6 +1444,11 @@ void ORGraphicsFieldItem::buildXML(QDomDocument & doc, QDomElement & parent)
       entity.appendChild(doc.createElement("leftToRight"));
   }
 
+  // do not collapse data
+  QDomElement dnc = doc.createElement("doNotCollapse");
+  dnc.appendChild(doc.createTextNode(doNotCollapse()?"true":"false"));;
+  entity.appendChild(dnc);
+
   parent.appendChild(entity);
 }
 
@@ -1519,6 +1527,7 @@ void ORGraphicsFieldItem::properties(QWidget * parent)
   le->leYSpacing->setText(QString::number(_ySpacing));
   le->_cbPageBreak->setChecked(_triggerPageBreak);
   le->_cbLeftToRight->setChecked(_leftToRight);
+  le->_cbDoNotCollapse->setChecked(_doNotCollapse);
 
   if(le->exec() == QDialog::Accepted)
   {
@@ -1565,7 +1574,7 @@ void ORGraphicsFieldItem::properties(QWidget * parent)
       setRect(0, 0, dw, dh);
       _setModified(scene(), true);
     }
-
+    _doNotCollapse = le->_cbDoNotCollapse->isChecked();
     update();
   }
 }

--- a/OpenRPT/wrtembed/graphicsitems.h
+++ b/OpenRPT/wrtembed/graphicsitems.h
@@ -218,7 +218,7 @@ class ORGraphicsFieldItem : public ORGraphicsRectItem
     bool trackBuiltinFormat() const { return _trackBuiltinFormat; }
     bool useSubTotal() const { return _useSubTotal; }
     QString format() const { return _format; }
-    bool doNotCollapse() const {return _doNotCollapse;}
+    bool collapse() const {return _collapse;}
 
     int textFlags() const { return _flags; }
 
@@ -247,7 +247,7 @@ class ORGraphicsFieldItem : public ORGraphicsRectItem
     qreal   _ySpacing;
     bool    _triggerPageBreak;
     bool    _leftToRight;
-    bool    _doNotCollapse;
+    bool    _collapse;
 };
 
 

--- a/OpenRPT/wrtembed/graphicsitems.h
+++ b/OpenRPT/wrtembed/graphicsitems.h
@@ -218,6 +218,7 @@ class ORGraphicsFieldItem : public ORGraphicsRectItem
     bool trackBuiltinFormat() const { return _trackBuiltinFormat; }
     bool useSubTotal() const { return _useSubTotal; }
     QString format() const { return _format; }
+    bool doNotCollapse() const {return _doNotCollapse;}
 
     int textFlags() const { return _flags; }
 
@@ -246,6 +247,7 @@ class ORGraphicsFieldItem : public ORGraphicsRectItem
     qreal   _ySpacing;
     bool    _triggerPageBreak;
     bool    _leftToRight;
+    bool    _doNotCollapse;
 };
 
 

--- a/common/parsexmlutils.cpp
+++ b/common/parsexmlutils.cpp
@@ -588,6 +588,8 @@ bool parseReportField(const QDomElement & elemSource, ORFieldData & fieldTarget)
       if(!fieldTarget.format.isEmpty())
         fieldTarget.trackTotal = true;
     }
+    else if(elemParam.tagName() == "doNotCollapse")
+      fieldTarget.doNotCollapse = (elemParam.text()=="true"? true : false);
     else
      qDebug("Tag not Parsed at <field>:%s\n", elemParam.tagName().toLatin1().data());
   }

--- a/common/parsexmlutils.cpp
+++ b/common/parsexmlutils.cpp
@@ -535,6 +535,7 @@ bool parseReportField(const QDomElement & elemSource, ORFieldData & fieldTarget)
   fieldTarget.ySpacing = 0;
   fieldTarget.triggerPageBreak = false;
   fieldTarget.leftToRight = false;
+  fieldTarget.collapse = false;
 
   for (int paramCounter = 0; paramCounter < params.count(); paramCounter++)
   {
@@ -588,8 +589,8 @@ bool parseReportField(const QDomElement & elemSource, ORFieldData & fieldTarget)
       if(!fieldTarget.format.isEmpty())
         fieldTarget.trackTotal = true;
     }
-    else if(elemParam.tagName() == "doNotCollapse")
-      fieldTarget.doNotCollapse = (elemParam.text()=="true"? true : false);
+    else if(elemParam.tagName() == "collapse")
+      fieldTarget.collapse = true;
     else
      qDebug("Tag not Parsed at <field>:%s\n", elemParam.tagName().toLatin1().data());
   }

--- a/common/parsexmlutils.h
+++ b/common/parsexmlutils.h
@@ -282,7 +282,7 @@ class ORFieldData : public ORObject
     qreal ySpacing;
     bool triggerPageBreak;
     bool leftToRight;
-    bool doNotCollapse;
+    bool collapse;
 
     virtual bool isField();
     virtual ORFieldData * toField();

--- a/common/parsexmlutils.h
+++ b/common/parsexmlutils.h
@@ -282,6 +282,7 @@ class ORFieldData : public ORObject
     qreal ySpacing;
     bool triggerPageBreak;
     bool leftToRight;
+    bool doNotCollapse;
 
     virtual bool isField();
     virtual ORFieldData * toField();


### PR DESCRIPTION
Jim found a few cases in which automatically collapsing null field objects can cause problems (in reports with specific spacing, that should not be interfered with).
- Added a check box ('Do Not Collapse') to the fieldeditor window, that will allow the user to select whether the field area should be reclaimed if the query result is NULL.
- Newly created fields have the `doNotCollapse` checkbox checked by default
The value of this textbox is reflected with a new element in the report XML