### PR TITLE
Textareas not wrapping properly

### DIFF
--- a/OpenRPT/renderer/renderobjects.cpp
+++ b/OpenRPT/renderer/renderobjects.cpp
@@ -258,49 +258,6 @@ void OROTextBox::setText(const QString & s)
   _text = s;
 }
 
-// insert spaces into long stretches of non-whitespace to allow wrapping
-// TODO: why doesn't Qt::TextWrapAnywhere work?
-// TODO: why do some lines not fill more when it looks like there's room?
-QString OROTextBox::textForcedToWrap(QPainter *p)
-{
-  QRectF  tbrect(0.0, 0.0,
-                 size().width()  * p->device()->logicalDpiX(),
-                 size().height() * p->device()->logicalDpiY());
-  QString result = text();
-  QFont   origfont = p->font();
-  QFontMetrics fm = p->fontMetrics();
-
-  p->setFont(_font);
-  if (fm.width(result) >= tbrect.width())
-  {
-    QRegExp wordre("(\\S+)");
-
-    int wordstart = 0;
-    while (wordre.indexIn(result, wordstart) != -1)
-    {
-      if (fm.width(wordre.cap(1)) <= tbrect.width())
-        wordstart += wordre.matchedLength();
-      else
-      {
-        QString longword = wordre.cap(1);
-        int i = longword.length() * (double)tbrect.width() / fm.width(longword);
-        while (i > 2 &&
-               fm.width(longword.left(i)) >= tbrect.width())
-           i--;
-        while (i < longword.length() &&
-               fm.width(longword.left(i)) < tbrect.width())
-           i++;
-        // i now points to the char that overflows
-        result.insert(wordstart + i - 1, " ");
-        wordstart += i - 1;
-      }
-    }
-  }
-
-  p->setFont(origfont);
-  return result;
-}
-
 void OROTextBox::setFont(const QFont & f)
 {
   _font = f;

--- a/OpenRPT/renderer/renderobjects.cpp
+++ b/OpenRPT/renderer/renderobjects.cpp
@@ -268,13 +268,12 @@ QString OROTextBox::textForcedToWrap(QPainter *p)
                  size().height() * p->device()->logicalDpiY());
   QString result = text();
   QFont   origfont = p->font();
+  QFontMetrics fm = p->fontMetrics();
 
   p->setFont(_font);
-
-  if (p->boundingRect(tbrect, _flags, result).width() >= tbrect.width())
+  if (fm.width(result) >= tbrect.width())
   {
     QRegExp wordre("(\\S+)");
-    QFontMetrics fm = p->fontMetrics();
 
     int wordstart = 0;
     while (wordre.indexIn(result, wordstart) != -1)

--- a/OpenRPT/renderer/renderobjects.h
+++ b/OpenRPT/renderer/renderobjects.h
@@ -208,7 +208,6 @@ class OROTextBox : public OROPrimitive
 
     QString text() const { return _text; };
     void setText(const QString &);
-    QString textForcedToWrap(QPainter *p);
 
     QFont font() const { return _font; };
     void setFont(const QFont &);


### PR DESCRIPTION
This fix is in relation to an issue brought up in a forum discussion [https://forums.xtuple.com/t/text-area-character-limit/5848/8](url)
The textarea would wrap only if spaces were added to the string to be rendered. Therefore, we had a function(`textForcedToWrap`) that measured(poorly) if the textarea `text` was too big for the allotted QRect. If it was it would add a space to the string.
I moved parts of that needed functionality into `TextElementSplitter::nextLine()`. That is lines 73-78.

Possible issue: Not sure what other line break characters to check for with QRegExp