### PR TITLE
[35247] *OpenRPT - Windows Default Font Issues

### DIFF
--- a/OpenRPT/wrtembed/reporthandler.cpp
+++ b/OpenRPT/wrtembed/reporthandler.cpp
@@ -1211,7 +1211,7 @@ void ReportHandler::editPaste(const QPointF & pos)
     }
   }
 }
-#pragma comment(linker,"/SUBSYSTEM:CONSOLE")
+
 void ReportHandler::editPreferences()
 {
   EditPreferences * dlgPref = new EditPreferences(0);

--- a/OpenRPT/wrtembed/reporthandler.cpp
+++ b/OpenRPT/wrtembed/reporthandler.cpp
@@ -1211,17 +1211,14 @@ void ReportHandler::editPaste(const QPointF & pos)
     }
   }
 }
-
+#pragma comment(linker,"/SUBSYSTEM:CONSOLE")
 void ReportHandler::editPreferences()
 {
   EditPreferences * dlgPref = new EditPreferences(0);
   if(dlgPref)
   {
     if(gwList.count()>0)
-    {
-      DocumentWindow * gw = activeDocumentWindow();
-      dlgPref->setDefaultFont(gw->_scene->getFont()); 
-    }
+      dlgPref->setDefaultFont(activeDocumentWindow()->_scene->getFont()); 
     else
       dlgPref->setDefaultFont(_sysFont); 
     dlgPref->setPageSize(_sysPageSize);
@@ -1232,7 +1229,8 @@ void ReportHandler::editPreferences()
     if(dlgPref->exec() == QDialog::Accepted)
     {
       //report level 
-      ORGraphicsRectItem::setDefaultEntityFont(dlgPref->defaultFont());
+      if(gwList.count()>0)
+        activeDocumentWindow()->_scene->setFont(dlgPref->defaultFont());
       gridShowAction->setChecked(dlgPref->showGrid());
       gridSnapAction->setChecked(dlgPref->snapGrid());
       gridOptions->setXInterval(dlgPref->gridSizeX());


### PR DESCRIPTION
when saving the preferences, the font was being saved to the `ORGraphicsRectItem` class, but upon opening the preferences window the font was being read from the `documentScene` causing the behavior reported